### PR TITLE
Debug telegram bot button callbacks

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -18,9 +18,23 @@ pub async fn run(bot: Bot, cfg: Arc<Config>) {
     }
     
     println!("Создаем listener для polling...");
-    let listener = teloxide::update_listeners::polling_default(bot.clone()).await;
-    log::info!("Polling listener создан");
-    println!("Polling listener создан успешно");
+    
+    // Настраиваем polling с явным указанием типов обновлений
+    use teloxide::types::AllowedUpdate;
+    use teloxide::update_listeners::Polling;
+    let allowed_updates = vec![
+        AllowedUpdate::Message,
+        AllowedUpdate::CallbackQuery,
+    ];
+    
+    let listener = Polling::builder(bot.clone())
+        .timeout(std::time::Duration::from_secs(10))
+        .limit(100)
+        .allowed_updates(allowed_updates)
+        .build();
+    
+    log::info!("Polling listener создан с поддержкой Message и CallbackQuery");
+    println!("Polling listener создан успешно с поддержкой кнопок");
     
     // Настройки для более стабильного polling
     println!("Настраиваем параметры polling...");

--- a/ИСПРАВЛЕНИЕ_КНОПОК.md
+++ b/ИСПРАВЛЕНИЕ_КНОПОК.md
@@ -1,0 +1,43 @@
+# Исправление проблемы с кнопками Telegram бота
+
+## Проблема
+Бот получал сообщения, но кнопки инлайн-клавиатуры не обрабатывались. В логах было видно:
+```
+DEBUG teloxide::dispatching::dispatcher > hinting allowed updates: [Message]
+```
+
+## Причина
+Использовался `teloxide::update_listeners::polling_default`, который по умолчанию принимает только сообщения типа `Message` и игнорирует `CallbackQuery` (нажатия на кнопки).
+
+## Решение
+Заменили `polling_default` на настраиваемый `Polling::builder` с явным указанием типов обновлений:
+
+### Исходный код (не работал):
+```rust
+let listener = teloxide::update_listeners::polling_default(bot.clone()).await;
+```
+
+### Исправленный код:
+```rust
+use teloxide::types::AllowedUpdate;
+use teloxide::update_listeners::Polling;
+let allowed_updates = vec![
+    AllowedUpdate::Message,
+    AllowedUpdate::CallbackQuery,
+];
+
+let listener = Polling::builder(bot.clone())
+    .timeout(std::time::Duration::from_secs(10))
+    .limit(100)
+    .allowed_updates(allowed_updates)
+    .build();
+```
+
+## Файл изменений
+- `src/handler.rs`: строки 20-34
+
+## Результат
+Теперь бот будет принимать как сообщения (`Message`), так и нажатия кнопок (`CallbackQuery`), и кнопки должны корректно обрабатываться.
+
+## Дополнительно исправлено
+- Использование устаревшего API: заменили `teloxide::update_listeners::polling` на `Polling::builder()` для соответствия teloxide 0.12.


### PR DESCRIPTION
Update Teloxide dispatcher to process inline keyboard button presses.

The bot was previously configured to only receive `Message` updates, causing it to ignore `CallbackQuery` events generated by inline keyboard button presses. This PR configures the dispatcher to handle both `Message` and `CallbackQuery` types, and updates the API usage to Teloxide 0.12.